### PR TITLE
Ensure TypeFromDefinition maps values to strings

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -52,29 +52,35 @@ type Dec<D extends Depth> = DecMap[D]
  *
  * Depth-limited so TS doesn’t infinitely expand on generics.
  */
-type DotFold<T, Prev extends string = "", Mode extends "paths" | "values" = "paths", D extends Depth = 10> = [
-	D,
+type DotFold<
+        T,
+        Prev extends string = "",
+        Mode extends "paths" | "values" = "paths",
+        Value = string,
+        D extends Depth = 10,
+> = [
+        D,
 ] extends [0]
-	? never
-	: {
-			[K in keyof T]: T[K] extends FieldDefinition
-				? Mode extends "paths"
-					? `${Prev}${K & string}`
-					: { [P in `${Prev}${K & string}`]: T[K]["defaultValue"] }
-				: T[K] extends FormDefinition
-					? DotFold<T[K], `${Prev}${K & string}.`, Mode, Dec<D>>
-					: never
-		}[keyof T]
+        ? never
+        : {
+                        [K in keyof T]: T[K] extends FieldDefinition
+                                ? Mode extends "paths"
+                                        ? `${Prev}${K & string}`
+                                        : { [P in `${Prev}${K & string}`]: Value }
+                                : T[K] extends FormDefinition
+                                        ? DotFold<T[K], `${Prev}${K & string}.`, Mode, Value, Dec<D>>
+                                        : never
+                }[keyof T]
 
 /** Public aliases */
-export type DotPaths<T, Prev extends string = "", D extends Depth = 10> = DotFold<T, Prev, "paths", D>
+export type DotPaths<T, Prev extends string = "", D extends Depth = 10> = DotFold<T, Prev, "paths", string, D>
 
-type DotPathsToValues<T, Prev extends string = "", D extends Depth = 10> = UnionToIntersection<
-	DotFold<T, Prev, "values", D>
+type DotPathsToValues<T, Prev extends string = "", Value = string, D extends Depth = 10> = UnionToIntersection<
+        DotFold<T, Prev, "values", Value, D>
 >
 
-export type TypeFromDefinition<T extends FormDefinition> = {
-	[K in keyof DotPathsToValues<T>]: DotPathsToValues<T>[K]
+export type TypeFromDefinition<T extends FormDefinition, Value = string> = {
+        [K in keyof DotPathsToValues<T, "", Value>]: DotPathsToValues<T, "", Value>[K]
 }
 
 export type FormSnapshot<T extends FormDefinition> = Record<DotPaths<T>, string>

--- a/tests/types.test-d.ts
+++ b/tests/types.test-d.ts
@@ -8,8 +8,8 @@ import type { AssertValidFormKeysDeep, UseStandardSchemaReturn } from "../src/ty
 type Validator = StandardSchemaV1<string>
 
 type TestFormDefinition = AssertValidFormKeysDeep<{
-	foo: {
-		label: "Foo"
+        foo: {
+                label: "Foo"
 		defaultValue: ""
 		validate: Validator
 	}
@@ -19,5 +19,32 @@ type Hook = typeof useStandardSchema extends (formDefinition: TestFormDefinition
 
 // Assert Hook matches exported UseStandardSchemaReturn<TestFormDefinition>
 export type HookMatches = Hook extends UseStandardSchemaReturn<TestFormDefinition> ? true : never
+
+// TypeFromDefinition should map every path to string even when defaultValue is missing
+type DefaultlessFormDefinition = AssertValidFormKeysDeep<{
+        foo: {
+                label: "Foo"
+                validate: Validator
+        }
+        nested: {
+                bar: {
+                        label: "Bar"
+                        defaultValue: "prepopulated"
+                        validate: Validator
+                }
+        }
+}>
+
+type DefaultlessValues = TypeFromDefinition<DefaultlessFormDefinition>
+type ExpectedDefaultlessValues = {
+        foo: string
+        "nested.bar": string
+}
+
+export type TypeFromDefinitionEmitsStrings = [DefaultlessValues] extends [ExpectedDefaultlessValues]
+        ? [ExpectedDefaultlessValues] extends [DefaultlessValues]
+                ? true
+                : never
+        : never
 
 export {}


### PR DESCRIPTION
## Summary
- update DotFold and TypeFromDefinition to always map form paths to string values
- add TypeScript type assertion to confirm TypeFromDefinition outputs strings even without default values

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6920a8381fa883328e7d15061f4134d0)