### PR TITLE
Clarify action submission usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ export function SubscriptionPage() {
 }
 ```
 
-- **`getForm(onSubmit)`**: Returns event handlers for the `<form>`. `onSubmit` only runs when valid.
+- **`getForm(onSubmit?, action?)`**: Returns event handlers for the `<form>`. Supply at least one handler; pass an `action` to opt into `<form action>` workflows while still receiving validation, resets, and metadata.
 - **`getField(name)`**: Returns the given field's metadata.
 
 ## Examples
@@ -112,6 +112,7 @@ Additional examples are available.
 - [Custom Component example](https://github.com/garystorey/use-standard-schema/tree/main/examples/custom-field-component.tsx) - Share reusable inputs via `FieldData`.
 - [Valibot example](https://github.com/garystorey/use-standard-schema/tree/main/examples/valibot-login.tsx) - Build a simple login form powered by Valibot validators.
 - [Shadcn Field example](https://github.com/garystorey/use-standard-schema/tree/main/examples/shadcn-field.tsx) - Wire `useStandardSchema` metadata into the shadcn/ui `Field` primitives.
+- [Action-driven submission example](https://github.com/garystorey/use-standard-schema/tree/main/examples/action-driven-submission.tsx) - Pair `getForm` with an `action` handler and `useFormStatus` while keeping aria wiring intact.
 
 ### Nested object fields
 
@@ -191,15 +192,27 @@ const { getForm, getField, getErrors, setField, setError, resetForm, isTouched, 
   useStandardSchema(myFormDefinition)
 ```
 
-### `getForm(onSubmit)`
+The hook also exposes `submissionError` for surfacing thrown action or submit errors.
 
-Returns the event handlers for the `<form>`. It validates all fields and only invokes your handler when everything passes.
+### `getForm(onSubmit?, action?)`
+
+Returns the event handlers for the `<form>` plus action metadata. It validates all fields and only invokes your handler or action when everything passes.
 
 ```tsx
-const form = getForm((values) => console.log(values))
+const form = getForm(
+  (values) => console.log(values),
+  async (values, formData) => submitWithAction(values, formData),
+)
 
-return <form {...form}>...</form>
+return <form {...form} action={form.action}>...</form>
 ```
+
+The returned object includes:
+
+- `onSubmit?`: A submit handler that prevents default when provided (omit if you prefer `<form action>`)
+- `action`: The function passed to the form's `action` attribute
+- `pending`: A boolean reflecting the `useActionState` pending status
+- `error`: Any error string thrown from the action handler
 
 ### `getField(name)`
 

--- a/examples/action-driven-submission.tsx
+++ b/examples/action-driven-submission.tsx
@@ -1,0 +1,70 @@
+import { useFormStatus } from "react-dom"
+import {
+  defineForm,
+  type TypeFromDefinition,
+  useStandardSchema,
+} from "use-standard-schema"
+
+const subscriptionForm = defineForm({
+  email: {
+    label: "Email",
+    validate: (value: string) =>
+      value.includes("@") ? value : "Enter a valid email address",
+    defaultValue: "",
+    description: "We'll send occasional updates.",
+  },
+})
+
+async function submitSubscription(
+  values: TypeFromDefinition<typeof subscriptionForm>,
+  formData: FormData,
+) {
+  "use server"
+  await sendSubscription(values, formData)
+}
+
+function SubmitButton({ disabled }: { disabled: boolean }) {
+  const status = useFormStatus()
+  return (
+    <button type="submit" disabled={disabled || status.pending}>
+      Subscribe
+    </button>
+  )
+}
+
+export function ActionDrivenSubscriptionForm() {
+  const { getForm, getField, submissionError } = useStandardSchema(subscriptionForm)
+  const form = getForm(undefined, submitSubscription)
+  const email = getField("email")
+  const describedBy = email.description ? email.describedById : undefined
+
+  return (
+    <form {...form} action={form.action}>
+      <label htmlFor={email.name}>{email.label}</label>
+      <input
+        id={email.name}
+        name={email.name}
+        defaultValue={email.defaultValue}
+        aria-describedby={describedBy}
+        aria-errormessage={email.errorId}
+      />
+      {email.description ? (
+        <p id={email.describedById}>{email.description}</p>
+      ) : null}
+      <p id={email.errorId} role="alert" aria-live="polite">
+        {email.error}
+      </p>
+      <SubmitButton disabled={form.pending} />
+      {submissionError ? <p role="alert">{submissionError}</p> : null}
+    </form>
+  )
+}
+
+// Replace with your action wiring (Server Action, fetch call, etc.).
+async function sendSubscription(
+  values: TypeFromDefinition<typeof subscriptionForm>,
+  formData: FormData,
+) {
+  console.log("Submitted values", values)
+  console.log("Raw FormData entries", Array.from(formData.entries()))
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,6 +85,13 @@ export type FormSnapshot<T extends FormDefinition> = Record<DotPaths<T>, string>
 
 export type ErrorEntry = { name: string; error: string; label: string }
 
+export type FormSubmitHandler<T extends FormDefinition> = (data: TypeFromDefinition<T>) => void | Promise<void>
+
+export type FormActionHandler<T extends FormDefinition> = (
+        data: TypeFromDefinition<T>,
+        formData: FormData,
+) => unknown | Promise<unknown>
+
 export type WatchValuesCallback<T extends FormDefinition> = {
 	(callback: (values: FormSnapshot<T>) => void): () => void
 	<Name extends DotPaths<T>>(name: Name, callback: (values: Pick<FormSnapshot<T>, Name>) => void): () => void
@@ -192,21 +199,30 @@ export interface FieldData {
 	error: string
 }
 
+export interface FormHandlers {
+        onSubmit?: (e: FormEvent) => Promise<void>
+        onFocus: (e: FocusEvent<HTMLFormElement>) => void
+        onBlur: (e: FocusEvent<HTMLFormElement>) => Promise<void>
+        onReset: () => void
+        action?: (formData: FormData) => void
+        pending: boolean
+        error: string | null
+}
+
 export interface UseStandardSchemaReturn<T extends FormDefinition> {
-	resetForm: () => void
-	getForm: (onSubmitHandler: (data: TypeFromDefinition<T>) => void) => {
-		onSubmit: (e: FormEvent) => Promise<void>
-		onFocus: (e: FocusEvent<HTMLFormElement>) => void
-		onBlur: (e: FocusEvent<HTMLFormElement>) => Promise<void>
-		onReset: () => void
-	}
-	getField: (
-		name: DotPaths<T>,
-	) => Partial<FieldData> & { defaultValue?: string; error: string; touched?: boolean; dirty?: boolean }
-	getErrors: (name?: DotPaths<T>) => ErrorEntry[]
-	setField: (name: DotPaths<T>, value: string) => Promise<void>
-	setError: (name: DotPaths<T>, info: ErrorInfo) => void
-	isTouched: (name?: DotPaths<T>) => boolean
-	isDirty: (name?: DotPaths<T>) => boolean
-	watchValues: WatchValuesCallback<T>
+        resetForm: () => void
+        getForm: {
+                (onSubmitHandler: FormSubmitHandler<T>, actionHandler?: FormActionHandler<T>): FormHandlers
+                (onSubmitHandler: undefined, actionHandler: FormActionHandler<T>): FormHandlers
+        }
+        getField: (
+                name: DotPaths<T>,
+        ) => Partial<FieldData> & { defaultValue?: string; error: string; touched?: boolean; dirty?: boolean }
+        getErrors: (name?: DotPaths<T>) => ErrorEntry[]
+        setField: (name: DotPaths<T>, value: string) => Promise<void>
+        setError: (name: DotPaths<T>, info: ErrorInfo) => void
+        isTouched: (name?: DotPaths<T>) => boolean
+        isDirty: (name?: DotPaths<T>) => boolean
+        watchValues: WatchValuesCallback<T>
+        submissionError: string | null
 }


### PR DESCRIPTION
## Summary
- require getForm consumers to supply an onSubmit handler, an action handler, or both and only expose action metadata when provided
- add FormHandlers typing/overloads to reflect the updated contract and export the helper type
- move the action-driven submission walkthrough into a dedicated example file while keeping the README guidance concise and accessible

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6930aa48d7f48332ba8e23db44a4f981)