### PR TITLE
Refine server action login example

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Additional examples are available.
 - [Dependent Fields example](https://github.com/garystorey/use-standard-schema/tree/main/examples/dependent-field-validation.tsx) - An example that keeps two related fields in sync using `setField` and `setError`.
 - [Custom Component example](https://github.com/garystorey/use-standard-schema/tree/main/examples/custom-field-component.tsx) - Share reusable inputs via `FieldData`.
 - [Valibot example](https://github.com/garystorey/use-standard-schema/tree/main/examples/valibot-login.tsx) - Build a simple login form powered by Valibot validators.
+- [React Server Action example](https://github.com/garystorey/use-standard-schema/tree/main/examples/server-action-login.tsx) - Keep a short login form wired to a server action using Zod.
 - [Shadcn Field example](https://github.com/garystorey/use-standard-schema/tree/main/examples/shadcn-field.tsx) - Wire `useStandardSchema` metadata into the shadcn/ui `Field` primitives.
 
 ### Nested object fields

--- a/examples/server-action-login.tsx
+++ b/examples/server-action-login.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import {
+    defineForm,
+    useStandardSchema,
+    validateForm,
+    type TypeFromDefinition,
+    type ErrorEntry,
+} from "use-standard-schema";
+import { z } from "zod";
+
+const loginForm = defineForm({
+    email: {
+        label: "Email",
+        defaultValue: "",
+        validate: z.string().email("Enter a valid email"),
+    },
+    password: {
+        label: "Password",
+        defaultValue: "",
+        validate: z.string().min(8, "Use at least 8 characters"),
+    },
+});
+
+async function login(values: TypeFromDefinition<typeof loginForm>) {
+    "use server";
+
+    const { isValid, errors } = await validateForm(loginForm, values);
+    if (!isValid) {
+        console.error("Server-side validation failed", errors);
+        return "Please correct the highlighted errors";
+    }
+
+    console.log("Server action login", values);
+    // Replace this stub with your auth logic (cookies, headers, etc.).
+    return `Logged in as ${values.email}`;
+}
+
+export default function ServerActionLoginExample() {
+    const { getForm, getField, getErrors } = useStandardSchema(loginForm);
+    const [message, setMessage] = useState<string | null>(null);
+    const [isPending, startTransition] = useTransition();
+
+    // getForm runs the built-in validation before calling the server action.
+    const formHandlers = getForm((values) => {
+        startTransition(async () => {
+            const result = await login(values);
+            setMessage(result);
+        });
+    });
+
+    const email = getField("email");
+    const password = getField("password");
+    const errors = getErrors();
+
+    return (
+        <form {...formHandlers}>
+            {errors.length > 0 && (
+                <div role="alert">
+                    <ul>
+                        {errors.map((error: ErrorEntry) => (
+                            <li key={error.name}>
+                                {error.label}: {error.error}
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            )}
+
+            <label htmlFor={email.name}>{email.label}</label>
+            <input
+                id={email.name}
+                name={email.name}
+                type="email"
+                defaultValue={email.defaultValue ?? ""}
+                aria-describedby={email.describedById}
+                aria-errormessage={email.errorId}
+            />
+            <p id={email.errorId}>{email.error}</p>
+
+            <label htmlFor={password.name}>{password.label}</label>
+            <input
+                id={password.name}
+                name={password.name}
+                type="password"
+                defaultValue={password.defaultValue ?? ""}
+                aria-describedby={password.describedById}
+                aria-errormessage={password.errorId}
+            />
+            <p id={password.errorId}>{password.error}</p>
+
+            <p role="status">{isPending ? "Submitting..." : message}</p>
+            <button type="submit" disabled={isPending}>
+                Log in
+            </button>
+        </form>
+    );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -534,7 +534,7 @@ function useStandardSchema<T extends FormDefinition>(formDefinition: T): UseStan
 	}
 }
 
-export { useStandardSchema, defineForm, toFormData }
+export { useStandardSchema, defineForm, toFormData, validateForm }
 export type {
 	ErrorEntry,
 	ErrorInfo,


### PR DESCRIPTION
## Summary
- switch to named React hook imports instead of namespace calls
- streamline the server-action login example by tracking the server response message only

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6939951297dc8332b4af2a2316eaae4c)