### PR TITLE
Fix watchValues dependency on schema validation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -515,7 +515,7 @@ function useStandardSchema<T extends FormDefinition>(formDefinition: T): UseStan
 				watchEntriesRef.current = watchEntriesRef.current.filter((existing) => existing !== entry)
 			}
 		}) as WatchValuesCallback<T>,
-		[],
+		[assertFieldExists],
 	)
 
 	return {


### PR DESCRIPTION
### Motivation
- Ensure `watchValues` is recreated when schema-related helpers change so field existence checks remain up-to-date and avoid stale validation behavior.

### Description
- Add `assertFieldExists` to the dependency array of the `useCallback` that defines `watchValues` in `src/index.ts` so the callback will update when that helper changes.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6982234533bc8332ae437cf4e88e53a8)