### PR TITLE
Fix field detection for nested groups

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -27,7 +27,10 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 
 /** Check if a value is a FieldDefinition */
 export function isFieldDefinition(obj: unknown): obj is FieldDefinition {
-	return typeof obj === "object" && obj !== null && "label" in obj && "validate" in obj
+	if (!isRecord(obj)) return false
+	const candidate = obj as { label?: unknown; validate?: unknown }
+	if (typeof candidate.label !== "string") return false
+	return extractValidator(candidate.validate) !== undefined
 }
 
 /** Convert a flat object of key-value pairs to FormData */

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -45,6 +45,20 @@ describe("helpers", () => {
 		expect(flat["a"].label).toBe("A")
 	})
 
+	it("flattenFormDefinition handles groups with label/validate field names", () => {
+		const trickyForm = defineForm({
+			group: {
+				label: { label: "Inner Label", defaultValue: "", validate: noopString() },
+				validate: { label: "Inner Validate", defaultValue: "", validate: noopString() },
+			},
+		})
+
+		const flat = flattenFormDefinition(trickyForm)
+
+		expect(Object.keys(flat).sort()).toEqual(["group.label", "group.validate"])
+		expect(flat["group.label"].label).toBe("Inner Label")
+	})
+
 	it("flattenDefaults returns dot-path defaults (empty string if missing)", () => {
 		const defs = flattenDefaults(form)
 		expect(defs).toEqual({


### PR DESCRIPTION
### Motivation

- Nested form groups using keys like `label` or `validate` were being misclassified as `FieldDefinition` objects, causing flattening and defaults extraction to behave incorrectly.

### Description

- Tighten `isFieldDefinition` to first ensure the candidate is a record, require the `label` to be a `string`, and confirm a real validator via `extractValidator` before treating an object as a `FieldDefinition` (changes in `src/helpers.ts`).
- Keep `flattenFormDefinition`/`flattenDefaults` behavior but rely on the improved `isFieldDefinition` so groups with keys named `label`/`validate` are correctly traversed as nested groups.
- Add a regression test that covers groups containing `label` and `validate` keys to ensure they are flattened to `group.label` and `group.validate` (changes in `tests/helpers.test.ts`).

### Testing

- Ran the helper unit tests with `npm test -- helpers.test.ts` and they passed (`1 file, 9 tests` all green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698a0a1881c883329219d01671488028)